### PR TITLE
build(deps): update rdf-canonize

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/rdf-ext/rdf-dataset-ext",
   "dependencies": {
-    "rdf-canonize": "^1.0.3",
+    "rdf-canonize": "^3.0.0",
     "readable-stream": "^3.4.0"
   },
   "devDependencies": {

--- a/test/toCanonical.test.js
+++ b/test/toCanonical.test.js
@@ -9,13 +9,13 @@ const ns = namespace('http://example.org/')
 const rdf = { ...model, ...dataset }
 
 describe('toCanonical', () => {
-  test('returns the canonical representation of the dataset', async () => {
+  test('returns the canonical representation of the dataset', () => {
     const blankNode = rdf.blankNode()
     const quad1 = rdf.quad(ns.subject1, ns.predicate, blankNode, ns.graph)
     const quad2 = rdf.quad(blankNode, ns.predicate, ns.object, ns.graph)
     const dataset = rdf.dataset([ quad1, quad2 ])
 
-    const result = await toCanonical(dataset)
+    const result = toCanonical(dataset)
 
     expect(result).toBe([
       '<http://example.org/subject1> <http://example.org/predicate> _:c14n0 <http://example.org/graph> .',
@@ -24,10 +24,10 @@ describe('toCanonical', () => {
     ].join('\n'))
   })
 
-  test('returns an empty string for an empty dataset', async () => {
+  test('returns an empty string for an empty dataset', () => {
     const dataset = rdf.dataset()
 
-    const result = await toCanonical(dataset)
+    const result = toCanonical(dataset)
 
     expect(result).toBe('')
   })

--- a/test/toCanonical.test.js
+++ b/test/toCanonical.test.js
@@ -9,13 +9,13 @@ const ns = namespace('http://example.org/')
 const rdf = { ...model, ...dataset }
 
 describe('toCanonical', () => {
-  test('returns the canonical representation of the dataset', () => {
+  test('returns the canonical representation of the dataset', async () => {
     const blankNode = rdf.blankNode()
     const quad1 = rdf.quad(ns.subject1, ns.predicate, blankNode, ns.graph)
     const quad2 = rdf.quad(blankNode, ns.predicate, ns.object, ns.graph)
     const dataset = rdf.dataset([ quad1, quad2 ])
 
-    const result = toCanonical(dataset)
+    const result = await toCanonical(dataset)
 
     expect(result).toBe([
       '<http://example.org/subject1> <http://example.org/predicate> _:c14n0 <http://example.org/graph> .',
@@ -24,10 +24,10 @@ describe('toCanonical', () => {
     ].join('\n'))
   })
 
-  test('returns an empty string for an empty dataset', () => {
+  test('returns an empty string for an empty dataset', async () => {
     const dataset = rdf.dataset()
 
-    const result = toCanonical(dataset)
+    const result = await toCanonical(dataset)
 
     expect(result).toBe('')
   })

--- a/toCanonical.js
+++ b/toCanonical.js
@@ -1,7 +1,7 @@
-const canonize = require('rdf-canonize')
+const URDNA2015Sync = require('rdf-canonize/lib/URDNA2015Sync.js')
 
 function toCanonical (dataset) {
-  return canonize.canonize([...dataset], { algorithm: 'URDNA2015' })
+  return new URDNA2015Sync().main(dataset)
 }
 
 module.exports = toCanonical

--- a/toCanonical.js
+++ b/toCanonical.js
@@ -1,7 +1,7 @@
 const canonize = require('rdf-canonize')
 
 function toCanonical (dataset) {
-  return canonize.canonizeSync([...dataset], { algorithm: 'URDNA2015' })
+  return canonize.canonize([...dataset], { algorithm: 'URDNA2015' })
 }
 
 module.exports = toCanonical


### PR DESCRIPTION
This updates `rdf-canonize` to the latest version in order to update the transitive dependency `node-forge` which has numerous [reported vulnerabilities](https://snyk.io/vuln/npm:node-forge)

Since `rdf-canonize` no longer exports (public) synchronous function, this would have to be a major release of this package