### PR TITLE
build(deps): relax readable-stream range

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/rdf-ext/rdf-dataset-ext",
   "dependencies": {
     "rdf-canonize": "^3.0.0",
-    "readable-stream": "^3.4.0"
+    "readable-stream": "3 - 4"
   },
   "devDependencies": {
     "@rdfjs/data-model": "^1.1.1",
@@ -34,7 +34,7 @@
     "@rdfjs/namespace": "^1.0.0",
     "c8": "^7.11.0",
     "codecov": "^3.8.3",
-    "isstream": "^0.1.2",
+    "is-stream": "^2.0.0",
     "mocha": "^9.2.0",
     "stricter-standard": "^0.2.0"
   }

--- a/test/toStream.test.js
+++ b/test/toStream.test.js
@@ -3,7 +3,7 @@ const { promisify } = require('util')
 const model = require('@rdfjs/data-model')
 const dataset = require('@rdfjs/dataset')
 const namespace = require('@rdfjs/namespace')
-const { isReadable } = require('isstream')
+const isStream = require('is-stream')
 const { describe, it } = require('mocha')
 const { finished } = require('readable-stream')
 const toStream = require('../toStream')
@@ -17,7 +17,7 @@ describe('toStream', () => {
 
     const result = toStream(dataset)
 
-    strictEqual(isReadable(result), true)
+    strictEqual(isStream.readable(result), true)
   })
 
   it('stream emits all quads of the dataset', async () => {


### PR DESCRIPTION
Many RDF/JS packages use `readable-stream@4`. This PR changes the dependency to allow any v3 or v4. This will reduce the risk of duplicate resolutions in projects